### PR TITLE
Port `a9a6b633bdf8e77ab6f9b9c10bae508cbcf427d7` into `main`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ScrollableContainers"
-version = "1.1.1"
+version = "1.1.2"
 authors = [
     { name="Vishal Pankaj Chandratreya" },
 ]

--- a/src/ScrollableContainers/__init__.py
+++ b/src/ScrollableContainers/__init__.py
@@ -1,4 +1,5 @@
-from .Qt5 import *
-from .Qt6 import *
-from .Tk import *
-from .Wx import *
+for module in ('.Qt5', '.Qt6', '.Tk', '.Wx'):
+    try:
+        exec(f'from {module} import *')
+    except ImportError:
+        pass


### PR DESCRIPTION
Do not error out if GUI libraries are missing.

Errors are postponed from the time of importing `ScrollableContainers` to the time the user attempts to access `ScrollableContainers.MissingLibrary`.