### PR TITLE
Formatted the PyGTK code in `README.md` as Ruff would.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ Add widgets to the `area` attribute of a `ScrollableAreaQt5`/`ScrollableAreaQt6`
 In GTK, containers are widgets, so they can be aligned in other containers.
 
 ```Python
-import gi; gi.require_version('Gtk', '3.0')
-import gi.repository.Gtk as Gtk
 import itertools
 
+import gi; gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 window = Gtk.Window()
-window.connect('destroy', Gtk.main_quit)
+window.connect("destroy", Gtk.main_quit)
 window.set_default_size(256, 128)
 
 scrolled_window = Gtk.ScrolledWindow()
@@ -91,9 +92,9 @@ grid.set_column_spacing(20)
 scrolled_window.add(grid)
 
 dim = 10
-for (i, j) in itertools.product(range(dim), repeat=2):
+for i, j in itertools.product(range(dim), repeat=2):
     label = Gtk.Label()
-    label.set_label(f'Label\n({i}, {j})')
+    label.set_label(f"Label\n({i}, {j})")
     grid.attach(label, j, i, 1, 1)
 
 window.show_all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ScrollableContainers"
-version = "2.0.1"
+version = "2.0.2"
 authors = [
     { name = "Vishal Pankaj Chandratreya" },
 ]


### PR DESCRIPTION
Except for the imports. The way PyGTK has to be imported is inherently incompatible with the recommendation specified in PEP8 (the Python style guide).