### PR TITLE
Floating scrollbars in Tkinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Add widgets to the `frame` attribute of a `ScrollableFrameTk` object.
   * Scrolling the mouse wheel while holding down Shift or swiping horizontally with two fingers on the touchpad
     triggers a horizontal scroll.
 * Horizontally centres the contents if the window is wider.
+* Reserves all space for child widgets in the window.
+  * The scrollbars do not take up any space. When scrolling or moving the cursor into the window, they are shown
+    briefly, and then hidden.
 
 ### Notes
 `"<Button-4>"`, `"<Button-5>"` and `"<MouseWheel>"` are bound to all widgets using `bind_all` to handle mouse wheel

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add widgets to the `frame` attribute of a `ScrollableFrameTk` object.
   * Scrolling the mouse wheel while holding down Shift or swiping horizontally with two fingers on the touchpad
     triggers a horizontal scroll.
 * Horizontally centres the contents if the window is wider.
-* Reserves all space for child widgets in the window.
+* Reserves all space in the window for child widgets.
   * The scrollbars do not take up any space. When scrolling or moving the cursor into the window, they are shown
     briefly, and then hidden.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ScrollableContainers"
-version = "2.1.0"
+version = "2.1.0rc0"
 authors = [
     { name = "Vishal Pankaj Chandratreya" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ScrollableContainers"
-version = "2.0.4"
+version = "2.1.0"
 authors = [
     { name = "Vishal Pankaj Chandratreya" },
 ]

--- a/src/ScrollableContainers/_tk.py
+++ b/src/ScrollableContainers/_tk.py
@@ -21,15 +21,11 @@ class ScrollableFrameTk(ttk.Frame):
         # vertical scrollbars do not touch.
         self._xscrollbar = ttk.Scrollbar(self, orient=tk.HORIZONTAL, command=self._xview)
         self._xscrollbar.bind("<Enter>", self._on_scrollbar_enter)
-        self._xscrollbar.bind("<ButtonPress>", self._on_scrollbar_enter)
         self._xscrollbar.bind("<Leave>", self._on_scrollbar_leave)
-        self._xscrollbar.bind("<ButtonRelease>", self._on_scrollbar_leave)
         self._xscrollbar.grid(row=1, column=0, sticky=tk.EW)
         self._yscrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self._yview)
         self._yscrollbar.bind("<Enter>", self._on_scrollbar_enter)
-        self._yscrollbar.bind("<ButtonPress>", self._on_scrollbar_enter)
         self._yscrollbar.bind("<Leave>", self._on_scrollbar_leave)
-        self._yscrollbar.bind("<ButtonRelease>", self._on_scrollbar_leave)
         self._yscrollbar.grid(row=0, column=1, sticky=tk.NS)
         self._hide_scrollbars_id = None
 
@@ -75,24 +71,22 @@ class ScrollableFrameTk(ttk.Frame):
 
     def _on_scrollbar_enter(self, _event: tk.Event | None = None):
         """
-        Called whenever it is necessary to keep the scrollbars visible. Cancel
-        the callback which will hide the horizontal and vertical scollbars.
+        Called when the mouse pointer enters a scrollbar. Cancel the callback
+        which will hide the scollbars.
 
-        :param _event: Enter or button event.
+        :param _event: Enter event.
         """
-        print(_event, self._hide_scrollbars_id)
         if self._hide_scrollbars_id:
             self.after_cancel(self._hide_scrollbars_id)
 
     def _on_scrollbar_leave(self, _event: tk.Event | None = None, ms: int = 1000):
         """
-        Called whenever it is no longer necessary to keep the scrollbars
-        visible. Hide the horizontal and vertical scrollbars afer a delay.
+        Called when the mouse pointer leaves a scrollbar. Hide the horizontal
+        and vertical scrollbars afer a delay.
 
-        :param _event: Leave or button event.
+        :param _event: Leave event.
         :param ms: Delay in milliseconds.
         """
-        print(_event, self._hide_scrollbars_id)
         self._hide_scrollbars_id = self.after(ms, self._hide_scrollbars)
 
     def _peek_scrollbars(self):

--- a/src/ScrollableContainers/_tk.py
+++ b/src/ScrollableContainers/_tk.py
@@ -65,7 +65,7 @@ class ScrollableFrameTk(ttk.Frame):
         self._xscrollbar.lower()
         self._yscrollbar.lower()
 
-    def _peek_scrollbars(self, ms:int=1000):
+    def _peek_scrollbars(self, ms: int = 1000):
         """
         Show the horizontal and vertical scrollbars. Hide them after a delay.
 

--- a/src/ScrollableContainers/_tk.py
+++ b/src/ScrollableContainers/_tk.py
@@ -21,11 +21,15 @@ class ScrollableFrameTk(ttk.Frame):
         # vertical scrollbars do not touch.
         self._xscrollbar = ttk.Scrollbar(self, orient=tk.HORIZONTAL, command=self._xview)
         self._xscrollbar.bind("<Enter>", self._on_scrollbar_enter)
+        self._xscrollbar.bind("<ButtonPress>", self._on_scrollbar_enter)
         self._xscrollbar.bind("<Leave>", self._on_scrollbar_leave)
+        self._xscrollbar.bind("<ButtonRelease>", self._on_scrollbar_leave)
         self._xscrollbar.grid(row=1, column=0, sticky=tk.EW)
         self._yscrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self._yview)
         self._yscrollbar.bind("<Enter>", self._on_scrollbar_enter)
+        self._yscrollbar.bind("<ButtonPress>", self._on_scrollbar_enter)
         self._yscrollbar.bind("<Leave>", self._on_scrollbar_leave)
+        self._yscrollbar.bind("<ButtonRelease>", self._on_scrollbar_leave)
         self._yscrollbar.grid(row=0, column=1, sticky=tk.NS)
         self._hide_scrollbars_id = None
 
@@ -71,22 +75,24 @@ class ScrollableFrameTk(ttk.Frame):
 
     def _on_scrollbar_enter(self, _event: tk.Event | None = None):
         """
-        Called when the mouse pointer enters a scrollbar. Cancel the callback
-        which will hide the scollbars.
+        Called whenever it is necessary to keep the scrollbars visible. Cancel
+        the callback which will hide the horizontal and vertical scollbars.
 
-        :param _event: Enter event.
+        :param _event: Enter or button event.
         """
+        print(_event, self._hide_scrollbars_id)
         if self._hide_scrollbars_id:
             self.after_cancel(self._hide_scrollbars_id)
 
     def _on_scrollbar_leave(self, _event: tk.Event | None = None, ms: int = 1000):
         """
-        Called when the mouse pointer leaves a scrollbar. Hide the horizontal
-        and vertical scrollbars afer a delay.
+        Called whenever it is no longer necessary to keep the scrollbars
+        visible. Hide the horizontal and vertical scrollbars afer a delay.
 
-        :param _event: Leave event.
+        :param _event: Leave or button event.
         :param ms: Delay in milliseconds.
         """
+        print(_event, self._hide_scrollbars_id)
         self._hide_scrollbars_id = self.after(ms, self._hide_scrollbars)
 
     def _peek_scrollbars(self):

--- a/src/ScrollableContainers/_tk.py
+++ b/src/ScrollableContainers/_tk.py
@@ -41,6 +41,7 @@ class ScrollableFrameTk(ttk.Frame):
         self._window = self._canvas.create_window((0, 0), window=self.frame, anchor=tk.NW)
         self.frame.bind("<Configure>", self._on_frame_configure)
         self._on_frame_expose_id = self.frame.bind("<Expose>", self._on_frame_expose)
+        self._hide_scrollbars_id = None
 
         # Initially, the vertical scrollbar is a hair below its topmost
         # position. Move it to said position. No harm in doing the equivalent
@@ -64,15 +65,16 @@ class ScrollableFrameTk(ttk.Frame):
         self._xscrollbar.lower()
         self._yscrollbar.lower()
 
-    def _peek_scrollbars(self, ms=1000):
+    def _peek_scrollbars(self, ms:int=1000):
         """
-        Show the horizontal and vertical scrollbars, and hide them after a
-        delay.
+        Show the horizontal and vertical scrollbars. Hide them after a delay.
 
         :param ms: Delay in milliseconds.
         """
+        if self._hide_scrollbars_id:
+            self.after_cancel(self._hide_scrollbars_id)
         self._show_scrollbars()
-        self.after(ms, self._hide_scrollbars)
+        self._hide_scrollbars_id = self.after(ms, self._hide_scrollbars)
 
     def _xview(self, *args, width: int | None = None):
         """
@@ -156,6 +158,7 @@ class ScrollableFrameTk(ttk.Frame):
         self.bind_all("<Button-4>", self._on_mouse_scroll)
         self.bind_all("<Button-5>", self._on_mouse_scroll)
         self.bind_all("<MouseWheel>", self._on_mouse_scroll)
+        self._peek_scrollbars()
 
     def _on_canvas_leave(self, _event: tk.Event | None = None):
         """

--- a/src/ScrollableContainers/_tk.py
+++ b/src/ScrollableContainers/_tk.py
@@ -17,20 +17,22 @@ class ScrollableFrameTk(ttk.Frame):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # Using the grid geometry manager ensures that the horizontal and
+        # vertical scrollbars do not touch.
+        self._xscrollbar = ttk.Scrollbar(self, orient=tk.HORIZONTAL, command=self._xview)
+        self._xscrollbar.grid(row=1, column=0, sticky=tk.EW)
+        self._yscrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self._yview)
+        self._yscrollbar.grid(row=0, column=1, sticky=tk.NS)
+
         # Scrollable canvas. This is the widget which actually manages
-        # scrolling. Using the grid geometry manager ensures that the
-        # horizontal and vertical scrollbars do not meet.
+        # scrolling. Initially, it will be above the scrollbars, so the latter
+        # won't be visible.
         self._canvas = tk.Canvas(self)
         self._canvas.bind("<Configure>", self._on_canvas_configure)
         self._canvas.bind("<Enter>", self._on_canvas_enter)
         self._canvas.bind("<Leave>", self._on_canvas_leave)
-        self._canvas.grid(row=0, column=0, sticky=tk.NSEW)
-
-        xscrollbar = ttk.Scrollbar(self, orient=tk.HORIZONTAL, command=self._xview)
-        xscrollbar.grid(row=1, column=0, sticky=tk.EW)
-        yscrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self._yview)
-        yscrollbar.grid(row=0, column=1, sticky=tk.NS)
-        self._canvas.configure(xscrollcommand=xscrollbar.set, yscrollcommand=yscrollbar.set)
+        self._canvas.configure(xscrollcommand=self._xscrollbar.set, yscrollcommand=self._yscrollbar.set)
+        self._canvas.grid(row=0, column=0, rowspan=2, columnspan=2, sticky=tk.NSEW)
 
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
@@ -45,6 +47,32 @@ class ScrollableFrameTk(ttk.Frame):
         # for the horizontal scrollbar.
         self._canvas.xview_moveto(0.0)
         self._canvas.yview_moveto(0.0)
+
+    def _show_scrollbars(self):
+        """
+        Move the horizontal and vertical scrollbars above the scrollable
+        canvas.
+        """
+        self._xscrollbar.lift()
+        self._yscrollbar.lift()
+
+    def _hide_scrollbars(self):
+        """
+        Move the horizontal and vertical scrollbars below the scrollable
+        canvas.
+        """
+        self._xscrollbar.lower()
+        self._yscrollbar.lower()
+
+    def _peek_scrollbars(self, ms=1000):
+        """
+        Show the horizontal and vertical scrollbars, and hide them after a
+        delay.
+
+        :param ms: Delay in milliseconds.
+        """
+        self._show_scrollbars()
+        self.after(ms, self._hide_scrollbars)
 
     def _xview(self, *args, width: int | None = None):
         """
@@ -165,3 +193,4 @@ class ScrollableFrameTk(ttk.Frame):
             case _:
                 message = f"event {event.num} on OS {_system!r} is not supported"
                 raise ValueError(message)
+        self._peek_scrollbars()


### PR DESCRIPTION
Native GUIs show scrollbars only when scrolling or moving the mouse inside the frame (as far as I have seen). Should try to do the same here.